### PR TITLE
refactor: update prompt for xcmAgent, stakingAgent and nominationPools Agent

### DIFF
--- a/agents/tools/staking-agent.ts
+++ b/agents/tools/staking-agent.ts
@@ -36,9 +36,9 @@ export const bondAgent = tool({
         "The token symbol of the network you are bonding on (e.g., 'DOT' for Polkadot, 'KSM' for Kusama). Defaults to 'DOT'.",
       ),
     payee: z
-      .enum(["Staked", "Stash", "Controller", "Account"])
+      .enum(["Staked", "Stash", "Controller", "Account", "None"])
       .describe(
-        "Specifies where staking rewards should be sent: 'Staked' (re-bonds rewards), 'Stash' (sends to stash account), 'Controller' (sends to controller account), or 'Account' (sends to a specific address). (Type: PalletStakingRewardDestination)",
+        "Specifies where staking rewards should be sent: 'Staked' (re-bonds rewards), 'Stash' (sends to stash account), 'Controller' (sends to controller account), or 'Account' (sends to a specific address) or 'None'. (Type: PalletStakingRewardDestination)",
       ),
     rewardAccount: z
       .string()
@@ -54,7 +54,7 @@ export const bondAgent = tool({
         controllerAccount: z.string(),
         value: z.string(),
         tokenSymbol: z.enum(["DOT", "KSM", "WND", "PAS"]),
-        payee: z.enum(["Staked", "Stash", "Controller", "Account"]),
+        payee: z.enum(["Staked", "Stash", "Controller", "Account", "None"]),
         rewardAccount: z.string().optional(),
       })
       .optional(),

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -55,24 +55,45 @@ You MUST always respond by calling one of the following tools based on the user'
     - Validate the recipient SS58 address.
     - Ensure sufficient balance before sending.
 
-• xcmAgent — Teleport or xcm do transfers of DOT, WND, or PAS tokens between polkadot-compatible chains.
+• xcmAgent — Teleports tokens (eg DOT, KSM, WND, PAS) between the relay chain and its system chains. Does a Reserve backed asset transfers otherwise.
     - Ask for confirmation before executing. Proceed only if the user types 'yes'.
     - Always use the current active network/chain as source network/chain.
     - Always use active account wallet address.
-    • xcmStablecoinFromAssetHub — Teleport or xcm do transfers of USDT or USDC stablecoins between polkadot-compatible chains.
+    • xcmStablecoinFromAssetHub — Does a Reserve backed asset transfer of USDT or USDC stablecoins between polkadot-sdk chains(eg:, between Polkadot Assethub and Hydration).
       - Ask for confirmation before executing. Proceed only if the user types 'yes'.
-      - Always get the recipient wallet address from the user.
+      - Always get the recipient wallet address from the user. The sender and recipient can or cannot be an Ethereum style address.
       - Do the above 2 steps for each stablecoin only.
 
-• stakingAgent — handles all staking operations for polkadot-sdk chains.
-    • bondAgent — Bond tokens for staking on a Proof-of-Stake network within the Polkadot or Kusama or Westend or Paseo ecosystem.
-    • nominateAgent — Nominate a list of validators to stake tokens with on a polkadot-sdk network.
-    • unbondAgent — Unbond a specific amount of tokens that were previously bonded for staking.
+• stakingAgent — handles all staking operations for polkadot-sdk chains. This agent manages bonding, nominating and unbonding actions.
+    • bondAgent — Bond tokens for staking on a Proof-of-Stake network (eg., Polkadot, Kusama, Westend, Paseo).
+      - Use this tool when the user requests to "stake", "bond", or "lockup" a specific amount of tokens.
+      - Always prompt the user for an account, amount and reward destination(payee). If the user provides a single account assume that account as stash and controller.
+      - Reward Destination(payee):
+        - If the user asks to "re-stake rewards,", "compound earnings,", or "add rewards to my stake," set the payee to Staked.
+        - If the user asks to "send reward to my stash" or "receive rewards as free balance," set the payee to Stash.
+        - If the user specifies a particular account, set the payee to Account and use the provided address.
+        - If the user says "do not send my reward anywhere", "send my reward nowhere" or "set payee to None", set the reward destination(payee) to None.
 
-• nominationPoolsAgent — handles operations related to nomination pools:
-   • joinNominationPoolAgent — Join an existing nomination pools on a network within the Polkadot ecosystem by bonding a specified amount of tokens.
-   • bondExtraNominationPoolAgent — Add more tokens to your existing bonded stake in a nomination pool. You can either bond additional tokens from your account's free balance or re-stake your accumulated rewards.
-   • unbondFromNominationPoolAgent — Initiate the unbonding process for a specified amount of tokens from a nomination pool you are currently a member of.
+    • nominateAgent — Nominate a list of validators to stake tokens with on a polkadot-sdk network.
+     - Trigger this tool when the user asks to "nominate", "choose validators" or "select validators".
+     - Do not get confused between this agent and the bondExtraNominationPoolAgent.
+     - Always require the controller account and the list of validator address/addresses(targets) from the user.
+    • unbondAgent — Unbond a specific amount of tokens that were previously bonded for staking.
+     - Use this tool when the user asks to "unbond", "unstake", "withdraw" or "remove" a specific amount of tokens form their bonded stake.
+     - Always require a controller account and the amount to unbond.
+
+• nominationPoolsAgent — handles operations exclusively for Polkadot's nomination pools:
+    • joinNominationPoolAgent — Join an existing nomination pool.
+     - Use this tool when the user asks to "join a pool" or "join a nomination pool".
+     - Always require pool id and the amount of tokens to bond.
+    • bondExtraNominationPoolAgent — Add more tokens to your existing bonded stake in a nomination pool.
+     - Do not get confused between this agent and the stakingAgent's bondAgent or nominateAgent(which require validator addresses).
+     - Use this tool when the user asks to "bond extra" to a pool, "add more funds" to a pool, or "restake rewards" from a pool.
+     - **IMPORTANT:** To re-stake rewards, you **MUST** set the extra parameter to an object with a single property: type with the literal string value "Rewards".Do not add any other properties or text.
+     - When the user provides an amount to bond (e.g., "10 DOT"), you **MUST** set the extra parameter to an object with two properties: type with the literal string value "FreeBalance" and amount with the numerical value provided by the user.
+   • unbondFromNominationPoolAgent — Unbond a specific amount of tokens from a nomination pool.
+     - Use this tool when the user asks to "unbond from a pool" or "remove funds" from a pool.
+     - Always require a member account(which can be different than current connected account or active account) and the funds upto unbonding points of the member account which the users wants to unbond.
 
 📣 IMPORTANT: Always highlight the important information in your responses such as network/chain names, wallet addresses, and tokens amounts account names etc.
 🚫 You must NOT guess, assume, or use your own knowledge under any circumstances.

--- a/app/globals.css
+++ b/app/globals.css
@@ -104,9 +104,6 @@
   }
   * {
     @apply border-border outline-ring/50;
-    user-select: none;
-    -moz-user-select: none;
-    -webkit-user-select: none;
   }
   body {
     @apply bg-background text-foreground;


### PR DESCRIPTION
Users are now able to copy their chat history and paste it into the prompt box. Added None as a Reward destination for staking if the user does not want the rewards. Corrected the prompt wording for the xcmAgent and improved the prompt for stakingAgent and nominationPoolsAgent so that the llm does not get confused between the two.
