### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled command line

### DIFF
--- a/scripts/run-with-pm.cjs
+++ b/scripts/run-with-pm.cjs
@@ -5,7 +5,7 @@
  * Usage: node scripts/run-with-pm.js <command>
  */
 
-const { execSync } = require("child_process");
+const { execSync, execFileSync } = require("child_process");
 
 function detectPackageManager() {
   try {
@@ -22,15 +22,18 @@ function detectPackageManager() {
 }
 
 const pm = detectPackageManager();
-const command = process.argv.slice(2).join(" ");
+const argv = process.argv.slice(2);
 
-if (!command) {
+if (argv.length === 0) {
   console.error("Error: No command provided");
   process.exit(1);
 }
 
+const subcommand = argv[0];
+const args = argv.slice(1);
+
 try {
-  execSync(`${pm} ${command}`, { stdio: "inherit" });
+  execFileSync(pm, [subcommand, ...args], { stdio: "inherit" });
 } catch (error) {
   process.exit(error.status || 1);
 }


### PR DESCRIPTION
Potential fix for [https://github.com/edgeware-network/agent-dot/security/code-scanning/1](https://github.com/edgeware-network/agent-dot/security/code-scanning/1)

General approach: avoid spawning a shell with a concatenated string. Instead, invoke the package manager executable directly using `execFileSync` (or `spawnSync`) and pass command and arguments as an array of strings. This prevents shell metacharacters in user input from being interpreted by a shell.

Best concrete fix here:

1. Replace the final `execSync` call with `execFileSync` from `child_process`.
2. Construct an argument array where:
   - The first element is the subcommand (e.g. `install`, `run`, etc.).
   - Remaining elements are the rest of the CLI arguments.
3. To preserve behavior, we should not naïvely join and re-split `command` by whitespace, as that would break quoted arguments. Instead, we can:
   - Keep `process.argv.slice(2)` in an array, and
   - Derive `subcommand` and `args` from that array (no need to ever create the `command` string).
4. Continue to use `execSync` for the version checks (`bun --version`, `pnpm --version`), as those do not involve untrusted data.

Concretely, in `scripts/run-with-pm.cjs`:

- Keep `const pm = detectPackageManager();`.
- Replace `const command = process.argv.slice(2).join(" ");` with `const argv = process.argv.slice(2);`.
- Adjust the “no command” guard to check `argv.length`.
- Extract `subcommand = argv[0]` and `args = argv.slice(1)` and call:
  ```js
  execFileSync(pm, [subcommand, ...args], { stdio: "inherit" });
  ```
- Import `execFileSync` alongside `execSync`.

This change keeps the semantics of “run the chosen package manager with the supplied arguments” without exposing a shell injection surface.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
